### PR TITLE
fix submodule url for general use

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "rscode"]
 	path = rscode
-	url = git@github.com:AlexanderJDupree/rscode.git
+	url = https://github.com/AlexanderJDupree/rscode.git


### PR DESCRIPTION
The url of the submodule is specified for Alex's account, use a generic publicly useable url instead.