### PR TITLE
use setuptools-scm for package version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,3 +154,12 @@ oresat_dxwifi/camera/data/*
 
 # Ignore .deb build targets
 oresat-dxwifi-software-server-*
+
+# Vim
+*.swp
+
+# MacOS
+.DS_Store
+
+# setuptools-scm
+_version.py

--- a/oresat_dxwifi/__init__.py
+++ b/oresat_dxwifi/__init__.py
@@ -1,1 +1,6 @@
-__version__ = "0.2.0"
+"""DxWiFi OLAF app"""
+
+try:
+    from ._version import version as __version__  # type: ignore
+except ImportError:
+    __version__ = "0.0.0"  # package is not installed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools"]
+requires = ["setuptools", "setuptools_scm"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -28,14 +28,14 @@ dynamic = ["version"]
 [project.scripts]
 oresat-c3 = "oresat_dxwifi.__main__:main"
 
-[tool.setuptools.dynamic]
-version = {attr = "oresat_dxwifi.__version__"}
-
 [tool.setuptools.packages.find]
 exclude = ["docs*"]
 
 [tool.setuptools.package-data]
 "*" = ["*.html"]
+
+[tool.setuptools_scm]
+write_to = "oresat_dxwifi/_version.py"
 
 [tool.black]
 line_length = 100

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,9 @@
+black
 build
-flake8
-oresat-olaf>=3.0.0
+build
+isort
 oresat-configs
-pyyaml
+oresat-olaf>=3.0.0
+pylama[all]
+setuptools
+setuptools-scm


### PR DESCRIPTION
This change will generate the package version based off of git tags and git comments. This will help identify which cards on FlatSat are using a unreleased version of `oresat-dxwifi` during integration / testing.

If the package is built of a tagged commit the version will match the tagged version, if the package is built of a non-tagged commit it will include the last tagged version, start of the commit hash, and the date; e.g.: `0.3.2.dev9+g9afbd58.d20240224`.

Also, we don't have to worry about updating `__version__` when tagging a commit.
