### PR TITLE
Remove direct usage of oresat-configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,20 +82,6 @@ Install the debian packages created from the libdxwifi instructions
 sudo dpkg -i *.deb
 ```
 
-## Build oresat_configs
-Clone Repository
-```bash
-cd /home/debian/src && \
-git clone https://github.com/oresat/oresat-configs
-```
-Install requirements
-```bash
-cd oresat-configs && \
-sudo pip install -r requirements.txt
-sudo ./build_and_install.sh
-```
-
-
 ## Build and install Oresat DxWiFi Software (OLAF app) Package
 Install requirements
 ```bash

--- a/oresat_dxwifi/__main__.py
+++ b/oresat_dxwifi/__main__.py
@@ -3,7 +3,6 @@
 import os
 
 from olaf import app, olaf_run, olaf_setup, render_olaf_template, rest_api
-from oresat_configs import NodeId
 
 from . import __version__
 from .resources.temperature import TemperatureResource

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ classifiers = [
     "Topic :: Software Development :: Embedded Systems",
 ]
 dependencies = [
-    "oresat-configs",
     "oresat-olaf>=3.0.0",
     "v4l2py==2.1.0",
 ]
@@ -59,7 +58,7 @@ ignore = "C0103,E203,W0613,R0902,R901,R0913,R0914,W1514,W0707,C901"
 max_line_length = 100
 
 [[tool.mypy.overrides]]
-module = "canopen,olaf,oresat_configs"
+module = "canopen,olaf"
 ignore_missing_imports = true
 
 [tool.isort]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 black
 build
 isort
-oresat-configs
-pyyaml[all]
+pyyaml
 v4l2py==2.1.0
 oresat-olaf>=3.0.0
 pylama[all]


### PR DESCRIPTION
NodeId in oresat-configs is deprecated, replaced by Card and cards.csv. It turns out though that this project doesn't use NodeId anymore. The import was a relic and further the import was the only usage of oresat-configs. That means any direct reference to it can be dropped both in pyproject.toml/requirements.txt and in the README install instructions. It's now brought in only indirectly via oresat-olaf.